### PR TITLE
Correctly filter shrub cards when calculating tree points

### DIFF
--- a/src/model/Forest.js
+++ b/src/model/Forest.js
@@ -200,7 +200,7 @@ export class Forest {
     }
 
     treePoints() {
-        return this.cards.filter(c => c.symbols.indexOf('tree') >= 0 || c.symbols.indexOf('shrub'))
+        return this.cards.filter(c => c.symbols.indexOf('tree') >= 0 || c.symbols.indexOf('shrub') >= 0)
             .map(c => c.points)
             .reduce((p, sum) => sum += p)
     }


### PR DESCRIPTION
The tree points summary at the bottom of the page applied the shrub filter incorrectly so was including points from any card that isn’t a shrub.

The result of `indexOf` was not being compared to anything so was being treated as a boolean, and -1 is truthy.

This fixes #15.

Before:

<img width="1347" alt="Screenshot 2024-11-23 at 20 46 09" src="https://github.com/user-attachments/assets/cd30e547-31a7-468d-ad29-2559a49b1b10">

After:

<img width="1343" alt="Screenshot 2024-11-23 at 20 46 22" src="https://github.com/user-attachments/assets/451941ed-0585-4f96-ad41-1bf62ce199b2">
