### PR TITLE
Switch the position of pawed and deer sections

### DIFF
--- a/src/views/DefineForestView.vue
+++ b/src/views/DefineForestView.vue
@@ -102,16 +102,16 @@
                           symbol="bat"
                           heading="bats"/>
     <CardAmountEditorList class="mt-4"
+                          :cards="pawedSide"
+                          :forest="forest"
+                          symbol="pawedAnimal"
+                          heading="pawedAnimals"/>
+    <CardAmountEditorList class="mt-4"
                           :cards="deerAndCloven"
                           :forest="forest"
                           symbol="deer"
                           symbol2="clovenHoofedAnimal"
                           heading="deerAndCloven"/>
-    <CardAmountEditorList class="mt-4"
-                          :cards="pawedSide"
-                          :forest="forest"
-                          symbol="pawedAnimal"
-                          heading="pawedAnimals"/>
     <div class="mt-4">
       <div class="text-center">
         <img :src="'./img/cave.png'" :alt="$t('cave')" @click="setCaveCount(forest.caveCount + 1)"/>


### PR DESCRIPTION
I found out I score the deer/cloven animals last because of the Roe Deers making you count symbols, which are smaller than the other, more obviuos scores - e.g. wolf, you already know (approximalely how many deers you have, because you drew cards from it).