### PR TITLE
Cache preferred language

### DIFF
--- a/src/components/NavigationAndButtons.vue
+++ b/src/components/NavigationAndButtons.vue
@@ -238,6 +238,7 @@ export default {
     },
     changeLanguage(newLang) {
       this.$i18n.locale = newLang
+      localStorage.setItem('preferredLanguage', newLang)
       event('languageChanged', {language: newLang})
     }
   }

--- a/src/i18n/get-browser-locale.js
+++ b/src/i18n/get-browser-locale.js
@@ -1,5 +1,10 @@
 
 export default function getBrowserLocale(options = {}) {
+    const preferredLanguage = localStorage.getItem('preferredLanguage')
+    if (preferredLanguage) {
+        return preferredLanguage
+    }
+
     const defaultOptions = { countryCodeOnly: false }
     const opt = { ...defaultOptions, ...options }
     const navigatorLocale =


### PR DESCRIPTION
The language detection algorithm reads the first from locales from the browser. Which may not be the language you want.

E.g. me, as a Bulgarian and web developer, I'd prefer my browser's locale to be in `en` rather than `bg`, but I'd also prefer the translation of the app (and card names) to be in Bulgarian by defalt, so I don't have to click through the menu every time.